### PR TITLE
Add ansible-10 to package.mask

### DIFF
--- a/etc/portage/package.mask
+++ b/etc/portage/package.mask
@@ -1,1 +1,2 @@
 >app-editors/emacs-31
+>app-admin/ansible-10


### PR DESCRIPTION
This pull request includes a small change to the `etc/portage/package.mask` file. The change adds a new package to the mask list.

* [`etc/portage/package.mask`](diffhunk://#diff-ad4b9d7ceb06ce58961433c858a7e37a69a3e1e69d46957dc7fb0a1dbb33e748R2): Added `app-admin/ansible-10` to the package mask list.