### PR TITLE
Add cf-terraforming and pipx

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -8,3 +8,6 @@ app-misc/google-cloud-cli
 dev-lang/php
 app-editors/emacs **
 net-misc/onedrive
+app-admin/cf-terraforming
+dev-python/pipx
+dev-python/userpath


### PR DESCRIPTION
This pull request includes updates to the `etc/portage/package.accept_keywords` file to add new packages for keyword acceptance.

New packages added:

* `app-admin/cf-terraforming`
* `dev-python/pipx`
* `dev-python/userpath`