### PR TITLE
chore(portage): update package mask with new versions of dotnet-sdk

### DIFF
--- a/etc/portage/package.mask
+++ b/etc/portage/package.mask
@@ -1,2 +1,4 @@
 >app-editors/emacs-31
 >app-admin/ansible-10
+>dev-dotnet/dotnet-sdk-bin-9
+>virtual/dotnet-sdk-9


### PR DESCRIPTION
This pull request includes a small change to the `package.mask` file. The change adds two new packages to the mask list.

* [`etc/portage/package.mask`](diffhunk://#diff-ad4b9d7ceb06ce58961433c858a7e37a69a3e1e69d46957dc7fb0a1dbb33e748R3-R4): Added `dev-dotnet/dotnet-sdk-bin-9` and `virtual/dotnet-sdk-9` to the mask list.