### PR TITLE
Fix package.mask

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -12,3 +12,5 @@ app-admin/cf-terraforming
 dev-python/pipx
 dev-python/userpath
 dev-php/symfony-cli
+dev-python/pyfzf
+app-emacs/emacs-common

--- a/etc/portage/package.mask
+++ b/etc/portage/package.mask
@@ -1,4 +1,4 @@
 >app-editors/emacs-31
 >app-admin/ansible-10
 >dev-dotnet/dotnet-sdk-bin-9
->virtual/dotnet-sdk-9
+>=virtual/dotnet-sdk-9.0

--- a/etc/portage/package.unmask
+++ b/etc/portage/package.unmask
@@ -1,1 +1,2 @@
 >=www-client/google-chrome-126.0.6478.55
+>=virtual/dotnet-sdk-9.0


### PR DESCRIPTION
This pull request includes updates to the `etc/portage` directory to adjust package keywords, masks, and unmask settings. The most important changes include adding new packages to `package.accept_keywords`, updating version constraints in `package.mask`, and unmasking a specific version in `package.unmask`.

Changes to package keywords:

* [`etc/portage/package.accept_keywords`](diffhunk://#diff-1eb996f30ecdbbd09a880b0149f5e6e171379e9c995010c912d93b2183b75c81R15-R16): Added `dev-python/pyfzf` and `app-emacs/emacs-common`.

Changes to package masks:

* [`etc/portage/package.mask`](diffhunk://#diff-ad4b9d7ceb06ce58961433c858a7e37a69a3e1e69d46957dc7fb0a1dbb33e748L4-R4): Updated version constraint for `virtual/dotnet-sdk` to `>=virtual/dotnet-sdk-9.0`.

Changes to package unmask:

* [`etc/portage/package.unmask`](diffhunk://#diff-7f51ce1462e389c56b6f5ac0e54baca7ebf505e5b837585bfb2a3a8a913543baR2): Unmasked `>=virtual/dotnet-sdk-9.0`.