### PR TITLE
feat: add support for 1password and op-cli-bin packages

### DIFF
--- a/etc/portage/package.accept_keywords
+++ b/etc/portage/package.accept_keywords
@@ -14,3 +14,4 @@ dev-python/userpath
 dev-php/symfony-cli
 dev-python/pyfzf
 app-emacs/emacs-common
+app-admin/op-cli-bin

--- a/etc/portage/package.license
+++ b/etc/portage/package.license
@@ -1,2 +1,4 @@
 www-client/google-chrome google-chrome
 app-admin/terraform BUSL-1.1
+app-admin/1password all-rights-reserved
+app-admin/op-cli-bin all-rights-reserved

--- a/etc/portage/package.use/1password
+++ b/etc/portage/package.use/1password
@@ -1,0 +1,1 @@
+app-admin/1password policykit cli

--- a/playbook.yml
+++ b/playbook.yml
@@ -154,6 +154,7 @@
           - dev-java/gradle-bin
           - dev-lang/ruby
           - dev-ruby/rdtool
+          - app-admin/1password # https://github.com/jaredallard/overlay/tree/main/app-admin/1password
 
     # - name: Install node.js packages globally.
     #   community.general.npm:


### PR DESCRIPTION
- Added app-admin/op-cli-bin to package.accept_keywords
- Added app-admin/1password and app-admin/op-cli-bin to package.license
- Created package.use file for app-admin/1password with policykit and cli use flags
- Updated playbook.yml to include app-admin/1password