### PR TITLE
feat(playbook): add gentoolkit to package list

### DIFF
--- a/etc/portage/package.mask
+++ b/etc/portage/package.mask
@@ -2,3 +2,4 @@
 >app-admin/ansible-10
 >dev-dotnet/dotnet-sdk-bin-9
 >=virtual/dotnet-sdk-9.0
+>=dev-dotnet/dotnet-sdk-9.0

--- a/playbook.yml
+++ b/playbook.yml
@@ -155,6 +155,7 @@
           - dev-lang/ruby
           - dev-ruby/rdtool
           - app-admin/1password # https://github.com/jaredallard/overlay/tree/main/app-admin/1password
+          - app-portage/gentoolkit
 
     # - name: Install node.js packages globally.
     #   community.general.npm:


### PR DESCRIPTION
This pull request includes changes to the package mask file and the playbook file to update and add new packages.

Package updates:

* [`etc/portage/package.mask`](diffhunk://#diff-ad4b9d7ceb06ce58961433c858a7e37a69a3e1e69d46957dc7fb0a1dbb33e748R5): Added `>=dev-dotnet/dotnet-sdk-9.0` to the package mask list.

Playbook updates:

* [`playbook.yml`](diffhunk://#diff-6377f8a1937054624eac73b02854e7f99081cb731582fcecd1b435c5ded73120R158): Added `app-portage/gentoolkit` to the list of packages to be installed.