### PR TITLE
feat(playbook): add Python tools and note pip deprecation

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -156,6 +156,9 @@
           - dev-ruby/rdtool
           - app-admin/1password # https://github.com/jaredallard/overlay/tree/main/app-admin/1password
           - app-portage/gentoolkit
+          - dev-python/virtualenv
+          - dev-python/virtualenvwrapper
+          - dev-python/pip      # deprecated
 
     # - name: Install node.js packages globally.
     #   community.general.npm:


### PR DESCRIPTION
This pull request updates the `playbook.yml` file to include additional Python-related tools and clarify the status of one package.

Additions to Python tools:

* Added `dev-python/virtualenv` and `dev-python/virtualenvwrapper` to the list of tools. These are commonly used for managing Python virtual environments.
* Added a note indicating that `dev-python/pip` is deprecated.